### PR TITLE
Added bin configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,6 @@
         "psr-4": {
             "Konsole\\": "src/Konsole"
         }
-    }
+    },
+    "bin": ["konsole"]
 }


### PR DESCRIPTION
> It instructs Composer to install the package's binaries to vendor/bin for any project that depends on that project.
> 
> This is a convenient way to expose useful scripts that would otherwise be hidden deep in the vendor/ directory.
> 
> [@Composer Docs](https://getcomposer.org/doc/articles/vendor-binaries.md#what-does-defining-a-vendor-binary-in-composer-json-do-)
